### PR TITLE
Reconstruction error fix in GUI

### DIFF
--- a/share/matlab/plotsim.m
+++ b/share/matlab/plotsim.m
@@ -142,8 +142,8 @@ if ( WHAT>2 ) %& mod(size(M,1),res.^2)==0 )
   end
   
    [Nx,Ny]=size(S);
-   wx=.5*(1 - cos(2*pi*(1:Nx/16)'/(Nx+1))); wx = [wx; ones(Nx*7/8,1); wx(end:-1:1)];
-   wy=.5*(1 - cos(2*pi*(1:Ny/16)'/(Ny+1))); wy = [wy; ones(Nx*7/8,1); wy(end:-1:1)];
+   %wx=.5*(1 - cos(2*pi*(1:Nx/16)'/(Nx+1))); wx = [wx; ones(Nx*7/8,1); wx(end:-1:1)];
+   %wy=.5*(1 - cos(2*pi*(1:Ny/16)'/(Ny+1))); wy = [wy; ones(Nx*7/8,1); wy(end:-1:1)];
    %FS=abs(fftshift(fft2(((wx*wy').*S)')));
    FS=fliplr(fft2(ifftshift(S')));
    if size(FS,1)==1


### PR DESCRIPTION
 If `Nx` or `Ny` are not a multiple of 8 the reconstruction in JEMRIS_sim fails. As `wx` and `wy` are not actually used, I suggest to comment those lines to fix the issue. Unless there is a good reason for `wx` and `wy` to exist.